### PR TITLE
chore: remove image validation to deploy on k8s

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -41,7 +41,7 @@ process-full-templates: process-templates
 	$(ENVSUBST_RUN) < $(K8S_TMPL_DIR)/service.yaml.tmpl > $(K8S_DIST_DIR)/service.yaml ; \
 	$(ENVSUBST_RUN) < $(K8S_TMPL_DIR)/ingress.yaml.tmpl > $(K8S_DIST_DIR)/ingress.yaml
 
-deploy-k8s: check-k8s-cluster-var validate-image process-templates
+deploy-k8s: check-k8s-cluster-var process-templates
 	$(KUBECTL_CMD) apply --record -f $(K8S_DIST_DIR)/deployment.yaml
 
 deploy-full-k8s: check-k8s-cluster-var process-full-templates deploy-k8s


### PR DESCRIPTION
## Why?
As the title says :)